### PR TITLE
revised Vagrantfile to use ubuntu/bionic64 base and allocate addition…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,15 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = "bento/ubuntu-18.04"
+  config.vm.box = "ubuntu/bionic64"
   config.vm.define "cyf"
   config.vm.hostname = "cyf"
-  config.ssh.forward_x11 = true
+  
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 2
+    v.customize ["modifyvm", :id, "--vram", "128","--graphicscontroller", "vboxsvga"]
+  end
+
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbook.yml"
-  end
+  end  
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure(2) do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
     v.cpus = 2
-    v.customize ["modifyvm", :id, "--vram", "128","--graphicscontroller", "vboxsvga"]
+    v.customize ["modifyvm", :id, "--vram", "128","--graphicscontroller", "vmsvga"]
   end
 
   config.vm.provision "ansible" do |ansible|


### PR DESCRIPTION
Revised Vagrantfile to use ubuntu/bionic64 base and allocate additional memory, CPU and GPU resources.

Before the VM would use the less up-to-date Bento base and if it used the ubuntu/bionic64 base with the default Virtualbox options  it would fail to reach the GUI on boot.